### PR TITLE
feat: 기본 국가 설정 기능 추가 (#5)

### DIFF
--- a/TimezoneAlarm.xcodeproj/project.pbxproj
+++ b/TimezoneAlarm.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		0926bbd73f084171927045e9 /* AlarmCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7cf857b200ed4242858a4214 /* AlarmCardView.swift */; };
 		f3fa27104f814f279aea8cf6 /* AlarmListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2055e47b01704302b9a69f9c /* AlarmListView.swift */; };
 		0d531177a8524c6eaff0cb63 /* AlarmFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = f1c854c0da854c6da495d9c1 /* AlarmFormView.swift */; };
+		b2c3d4e5f6a7b8c9d0e1f2a3 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = c3d4e5f6a7b8c9d0e1f2a3b4 /* SettingsView.swift */; };
 		a1b2c3d4e5f6a7b8c9d0e1f3 /* AlarmAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = a1b2c3d4e5f6a7b8c9d0e1f4 /* AlarmAlertView.swift */; };
 		694c41ecac5043e7aa3f3d070dd315aa /* AlarmScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = a1b2c3d4e5f6a7b8c9d0e1f2 /* AlarmScheduler.swift */; };
 		51C503CA6D2F46F88D80A5DF /* TimezoneAlarmApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BB57D6CC548EA702320A886 /* TimezoneAlarmApp.swift */; };
@@ -41,6 +42,7 @@
 		23c1b019e3ca48f99a2512ba /* Alarm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Alarm.swift; sourceTree = "<group>"; };
 		a53bffc5b8d7435f85512728 /* Country.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Country.swift; sourceTree = "<group>"; };
 		f1c854c0da854c6da495d9c1 /* AlarmFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlarmFormView.swift; sourceTree = "<group>"; };
+		c3d4e5f6a7b8c9d0e1f2a3b4 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		a1b2c3d4e5f6a7b8c9d0e1f4 /* AlarmAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlarmAlertView.swift; sourceTree = "<group>"; };
 		a1b2c3d4e5f6a7b8c9d0e1f2 /* AlarmScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlarmScheduler.swift; sourceTree = "<group>"; };
 		5D25D70292A40C0AA7B7CE59 /* TimezoneAlarm.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = TimezoneAlarm.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -109,6 +111,7 @@
 				2055e47b01704302b9a69f9c /* AlarmListView.swift */,
 				f1c854c0da854c6da495d9c1 /* AlarmFormView.swift */,
 				a1b2c3d4e5f6a7b8c9d0e1f4 /* AlarmAlertView.swift */,
+				c3d4e5f6a7b8c9d0e1f2a3b4 /* SettingsView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -237,6 +240,7 @@
 				f3fa27104f814f279aea8cf6 /* AlarmListView.swift in Sources */,
 				0d531177a8524c6eaff0cb63 /* AlarmFormView.swift in Sources */,
 				a1b2c3d4e5f6a7b8c9d0e1f3 /* AlarmAlertView.swift in Sources */,
+				b2c3d4e5f6a7b8c9d0e1f2a3 /* SettingsView.swift in Sources */,
 				694c41ecac5043e7aa3f3d070dd315aa /* AlarmScheduler.swift in Sources */,
 				9BCFF78819A255F7ECC7C92C /* ContentView.swift in Sources */,
 				51C503CA6D2F46F88D80A5DF /* TimezoneAlarmApp.swift in Sources */,

--- a/TimezoneAlarm/ContentView.swift
+++ b/TimezoneAlarm/ContentView.swift
@@ -12,68 +12,129 @@ struct ContentView: View {
     @State private var viewModel = AlarmViewModel()
     @State private var showAlarmForm = false
     @State private var showAlarmAlert = false
+    @State private var showSettings = false
+    @State private var editMode: EditMode = .inactive
     @EnvironmentObject var notificationDelegate: NotificationDelegate
+    
+    private var hasDefaultCountry: Bool {
+        UserDefaults.standard.string(forKey: "defaultCountryId") != nil
+    }
     
     var body: some View {
         NavigationView {
-            if viewModel.alarms.isEmpty {
-                // Empty State
-                VStack(spacing: 20) {
+            VStack(spacing: 0) {
+                // 커스텀 헤더
+                HStack {
                     Spacer()
-                    
-                    // 알람 아이콘
-                    Image(systemName: "alarm")
-                        .font(.system(size: 80))
-                        .foregroundStyle(.secondary)
-                    
-                    // Title
-                    Text("No Alarms Yet")
-                        .font(.title2)
-                        .fontWeight(.semibold)
-                    
-                    // Description
-                    Text("Tap + to add your first alarm")
-                        .font(.body)
-                        .foregroundStyle(.secondary)
-                    
-                    // Add New Alarm 버튼
-                    Button(action: {
-                        showAlarmForm = true
-                    }) {
-                        Text("Add New Alarm")
-                            .font(.headline)
-                            .foregroundColor(.white)
-                            .frame(maxWidth: .infinity)
-                            .padding()
-                            .background(Color.accentColor)
-                            .cornerRadius(12)
-                    }
-                    .padding(.horizontal, 40)
-                    .padding(.top, 8)
-                    
-                    Spacer()
-                }
-                .padding()
-                .navigationTitle("Alarms")
-                .sheet(isPresented: $showAlarmForm) {
-                    AlarmFormView(viewModel: viewModel)
-                }
-            } else {
-                // Alarm List
-                AlarmListView(viewModel: viewModel, showAlarmForm: $showAlarmForm)
-                    .navigationTitle("Alarms")
-                    .toolbar {
-                        ToolbarItem(placement: .navigationBarTrailing) {
+                    if viewModel.alarms.isEmpty {
+                        // Empty State - 버튼만 표시
+                        HStack(spacing: 12) {
                             Button(action: {
                                 showAlarmForm = true
                             }) {
                                 Image(systemName: "plus")
+                                    .font(.system(size: 16, weight: .medium))
+                                    .foregroundColor(.primary)
+                                    .frame(width: 28, height: 28)
+                                    .background(Circle().fill(Color(.systemGray6)))
+                            }
+                            Button(action: {
+                                showSettings = true
+                            }) {
+                                Image(systemName: "gearshape")
+                                    .font(.system(size: 16, weight: .medium))
+                                    .foregroundColor(.primary)
+                                    .frame(width: 28, height: 28)
+                                    .background(Circle().fill(Color(.systemGray6)))
                             }
                         }
+                        .padding(.trailing, 16)
+                    } else {
+                        // Alarm List
+                        if editMode == .active {
+                            Button("Done") {
+                                withAnimation {
+                                    editMode = .inactive
+                                }
+                            }
+                            .padding(.trailing, 16)
+                        } else {
+                            HStack(spacing: 12) {
+                                Button(action: {
+                                    showAlarmForm = true
+                                }) {
+                                    Image(systemName: "plus")
+                                        .font(.system(size: 16, weight: .medium))
+                                        .foregroundColor(.primary)
+                                        .frame(width: 28, height: 28)
+                                        .background(Circle().fill(Color(.systemGray6)))
+                                }
+                                Button(action: {
+                                    showSettings = true
+                                }) {
+                                    Image(systemName: "gearshape")
+                                        .font(.system(size: 16, weight: .medium))
+                                        .foregroundColor(.primary)
+                                        .frame(width: 28, height: 28)
+                                        .background(Circle().fill(Color(.systemGray6)))
+                                }
+                            }
+                            .padding(.trailing, 16)
+                        }
                     }
-                    .sheet(isPresented: $showAlarmForm) {
-                        AlarmFormView(viewModel: viewModel)
+                }
+                .frame(height: 44)
+                .background(Color(.systemBackground))
+                
+                // 컨텐츠
+                if viewModel.alarms.isEmpty {
+                    // Empty State
+                    VStack(spacing: 20) {
+                        Spacer()
+                        
+                        // 알람 아이콘
+                        Image(systemName: "alarm")
+                            .font(.system(size: 80))
+                            .foregroundStyle(.secondary)
+                        
+                        // Title
+                        Text("No Alarms Yet")
+                            .font(.title2)
+                            .fontWeight(.semibold)
+                        
+                        // Description
+                        Text("Tap + to add your first alarm")
+                            .font(.body)
+                            .foregroundStyle(.secondary)
+                        
+                        // Add New Alarm 버튼
+                        Button(action: {
+                            showAlarmForm = true
+                        }) {
+                            Text("Add New Alarm")
+                                .font(.headline)
+                                .foregroundColor(.white)
+                                .frame(maxWidth: .infinity)
+                                .padding()
+                                .background(Color.accentColor)
+                                .cornerRadius(12)
+                        }
+                        .padding(.horizontal, 40)
+                        .padding(.top, 8)
+                        
+                        Spacer()
                     }
+                    .padding()
+                } else {
+                    // Alarm List
+                    AlarmListView(viewModel: viewModel, showAlarmForm: $showAlarmForm, showSettings: $showSettings, editMode: $editMode)
+                }
+            }
+            .sheet(isPresented: $showAlarmForm) {
+                AlarmFormView(viewModel: viewModel)
+            }
+            .sheet(isPresented: $showSettings) {
+                SettingsView()
             }
         }
         .onAppear {

--- a/TimezoneAlarm/Views/AlarmFormView.swift
+++ b/TimezoneAlarm/Views/AlarmFormView.swift
@@ -63,6 +63,11 @@ struct AlarmFormView: View {
                 _selectedCountry = State(initialValue: country)
             }
         } else {
+            // 새 알람 생성 시 기본 국가 로드
+            if let countryId = UserDefaults.standard.string(forKey: "defaultCountryId"),
+               let country = Country.popularCountries.first(where: { $0.id == countryId }) {
+                _selectedCountry = State(initialValue: country)
+            }
             // 새 알람 생성 시 날짜 초기값을 내일 날짜로 설정
             _selectedDate = State(initialValue: tomorrow)
         }

--- a/TimezoneAlarm/Views/AlarmListView.swift
+++ b/TimezoneAlarm/Views/AlarmListView.swift
@@ -10,12 +10,15 @@ import SwiftUI
 struct AlarmListView: View {
     @Bindable var viewModel: AlarmViewModel
     @Binding var showAlarmForm: Bool
-    @State private var editMode: EditMode = .inactive
+    @Binding var showSettings: Bool
+    @Binding var editMode: EditMode
     @State private var editingAlarm: Alarm?
     
-    init(viewModel: AlarmViewModel, showAlarmForm: Binding<Bool> = .constant(false)) {
+    init(viewModel: AlarmViewModel, showAlarmForm: Binding<Bool> = .constant(false), showSettings: Binding<Bool> = .constant(false), editMode: Binding<EditMode> = .constant(.inactive)) {
         self.viewModel = viewModel
         self._showAlarmForm = showAlarmForm
+        self._showSettings = showSettings
+        self._editMode = editMode
     }
     
     var body: some View {
@@ -52,17 +55,6 @@ struct AlarmListView: View {
         }
         .listStyle(.plain)
         .environment(\.editMode, $editMode)
-        .toolbar {
-            ToolbarItem(placement: .navigationBarTrailing) {
-                if editMode == .active {
-                    Button("Done") {
-                        withAnimation {
-                            editMode = .inactive
-                        }
-                    }
-                }
-            }
-        }
         .sheet(item: $editingAlarm) { alarm in
             AlarmFormView(viewModel: viewModel, editingAlarm: alarm)
         }

--- a/TimezoneAlarm/Views/SettingsView.swift
+++ b/TimezoneAlarm/Views/SettingsView.swift
@@ -1,0 +1,84 @@
+//
+//  SettingsView.swift
+//  TimezoneAlarm
+//
+//  Created on 2024.
+//
+
+import SwiftUI
+
+struct SettingsView: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var selectedCountry: Country?
+    
+    private var isFormValid: Bool {
+        selectedCountry != nil
+    }
+    
+    var body: some View {
+        NavigationView {
+            Form {
+                Section {
+                    NavigationLink {
+                        CountrySelectionView(selectedCountry: $selectedCountry)
+                    } label: {
+                        HStack {
+                            Text("Default Country")
+                            Spacer()
+                            if let country = selectedCountry {
+                                HStack(spacing: 8) {
+                                    Text(country.flag)
+                                    Text(country.name)
+                                        .foregroundColor(.secondary)
+                                }
+                            } else {
+                                Text("Select Country")
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                    }
+                } header: {
+                    Text("Default Country")
+                } footer: {
+                    Text("This country will be used as the default when creating new alarms.")
+                }
+            }
+            .navigationTitle("Settings")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Back") {
+                        dismiss()
+                    }
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Save") {
+                        saveDefaultCountry()
+                    }
+                    .disabled(!isFormValid)
+                }
+            }
+            .onAppear {
+                loadDefaultCountry()
+            }
+        }
+    }
+    
+    private func loadDefaultCountry() {
+        if let countryId = UserDefaults.standard.string(forKey: "defaultCountryId"),
+           let country = Country.popularCountries.first(where: { $0.id == countryId }) {
+            selectedCountry = country
+        }
+    }
+    
+    private func saveDefaultCountry() {
+        guard let country = selectedCountry else { return }
+        UserDefaults.standard.set(country.id, forKey: "defaultCountryId")
+        dismiss()
+    }
+}
+
+#Preview {
+    SettingsView()
+}
+


### PR DESCRIPTION
## 구현 내용

이슈 #5 구현

### 주요 기능
- ✅ 기본 국가 설정 화면 (SettingsView) 추가
- ✅ 알람 생성 시 설정한 기본 국가가 자동 선택되도록 구현
- ✅ 상단바 커스텀 헤더로 변경하여 아이콘 완전 분리
- ✅ 플러스 아이콘과 설정 아이콘을 각각 독립적인 동그라미 배경으로 표시

### 변경 사항
- `SettingsView.swift` 추가: 기본 국가 설정 화면
- `ContentView.swift`: 커스텀 헤더로 변경, 설정 버튼 추가
- `AlarmFormView.swift`: 기본 국가 자동 선택 기능 추가
- `AlarmListView.swift`: editMode를 ContentView에서 관리하도록 변경
- `AlarmScheduler.swift`: 경고 수정 (@preconcurrency, unused variables)

### 테스트
- [x] 빌드 성공
- [x] 기본 국가 설정 및 저장 확인
- [x] 알람 생성 시 기본 국가 자동 선택 확인
- [x] UI 아이콘 분리 확인

Closes #5