### PR TITLE
feat: 알람 폼 및 카드 UI 개선

### DIFF
--- a/TimezoneAlarm/ContentView.swift
+++ b/TimezoneAlarm/ContentView.swift
@@ -34,6 +34,9 @@ struct ContentView: View {
                 VStack(spacing: 0) {
                     // 커스텀 헤더 (배경색, 블러, 그림자 적용)
                     HStack {
+                        Text("Syncly")
+                            .font(.geist(size: 24, weight: .bold))
+                            .foregroundColor(.appTextPrimary)
                         Spacer()
                         if viewModel.alarms.isEmpty {
                             // Empty State - 버튼만 표시
@@ -97,7 +100,7 @@ struct ContentView: View {
                         }
                     }
                     .frame(height: 44)
-                    .padding(.horizontal, 20)
+                    .padding(.horizontal, 16)
                     .padding(.vertical, 6)
                     .background(Color.appHeaderBackground)
                     .background(.ultraThinMaterial)

--- a/TimezoneAlarm/Resources/en.lproj/Localizable.strings
+++ b/TimezoneAlarm/Resources/en.lproj/Localizable.strings
@@ -43,4 +43,3 @@
 "settings.title" = "Settings";
 "settings.default_country" = "Default Country";
 "settings.select_country" = "Select Country";
-"settings.default_country_footer" = "This country will be used as the default when creating new alarms.";

--- a/TimezoneAlarm/Resources/id.lproj/Localizable.strings
+++ b/TimezoneAlarm/Resources/id.lproj/Localizable.strings
@@ -43,4 +43,3 @@
 "settings.title" = "Pengaturan";
 "settings.default_country" = "Negara Default";
 "settings.select_country" = "Pilih Negara";
-"settings.default_country_footer" = "Negara ini akan digunakan sebagai default saat membuat alarm baru.";

--- a/TimezoneAlarm/Resources/ja.lproj/Localizable.strings
+++ b/TimezoneAlarm/Resources/ja.lproj/Localizable.strings
@@ -43,4 +43,3 @@
 "settings.title" = "設定";
 "settings.default_country" = "デフォルトの国";
 "settings.select_country" = "国を選択";
-"settings.default_country_footer" = "新しいアラームを作成する際にデフォルトで使用される国です。";

--- a/TimezoneAlarm/Resources/ko.lproj/Localizable.strings
+++ b/TimezoneAlarm/Resources/ko.lproj/Localizable.strings
@@ -43,4 +43,3 @@
 "settings.title" = "설정";
 "settings.default_country" = "기본 국가";
 "settings.select_country" = "국가 선택";
-"settings.default_country_footer" = "새 알람을 만들 때 기본으로 사용됩니다";

--- a/TimezoneAlarm/Resources/pt-BR.lproj/Localizable.strings
+++ b/TimezoneAlarm/Resources/pt-BR.lproj/Localizable.strings
@@ -43,4 +43,3 @@
 "settings.title" = "Configurações";
 "settings.default_country" = "País Padrão";
 "settings.select_country" = "Selecionar País";
-"settings.default_country_footer" = "Este país será usado como padrão ao criar novos alarmes.";

--- a/TimezoneAlarm/Views/AlarmCardView.swift
+++ b/TimezoneAlarm/Views/AlarmCardView.swift
@@ -47,7 +47,7 @@ struct AlarmCardView: View {
                         // 알람명
                         Text(alarm.name)
                             .font(.geist(size: 18, weight: .semibold))
-                            .foregroundColor(.appTextPrimary)
+                            .foregroundColor(alarm.isEnabled ? .appTextPrimary : .appTextPrimary.opacity(0.6))
                         
                         Spacer()
                         
@@ -86,11 +86,11 @@ struct AlarmCardView: View {
                     HStack(alignment: .firstTextBaseline, spacing: 8) {
                         Text(alarm.timeOnly)
                             .font(.geist(size: 36, weight: .bold))
-                            .foregroundColor(.appTextPrimary)
+                            .foregroundColor(alarm.isEnabled ? .appTextPrimary : .appTextPrimary.opacity(0.6))
                         
                         Text(alarm.amPm)
                             .font(.geist(size: 14, weight: .semibold))
-                            .foregroundColor(.appTextSecondary)
+                            .foregroundColor(alarm.isEnabled ? .appTextSecondary : .appTextSecondary.opacity(0.6))
                             .padding(.leading, 1)
                         
                         // 국가 정보
@@ -170,6 +170,15 @@ struct AlarmCardView: View {
                                 endRadius: 200
                             )
                         )
+                )
+                .overlay(
+                    // 비활성화 시 회색 틴트
+                    Group {
+                        if !alarm.isEnabled {
+                            RoundedRectangle(cornerRadius: 24)
+                                .fill(Color.gray.opacity(0.4))
+                        }
+                    }
                 )
                 .shadow(color: Color.appShadow.opacity(0.3), radius: 8, x: 0, y: 4)
             }
@@ -275,4 +284,3 @@ struct CustomToggle: View {
     )
     .padding()
 }
-

--- a/TimezoneAlarm/Views/SettingsView.swift
+++ b/TimezoneAlarm/Views/SettingsView.swift
@@ -54,12 +54,6 @@ struct SettingsView: View {
                                 }
                             }
                         }
-                        
-                        // Footer 텍스트
-                        Text(NSLocalizedString("settings.default_country_footer", comment: "Default country footer"))
-                            .font(.geist(size: 14, weight: .regular))
-                            .foregroundColor(.appTextSecondary)
-                            .frame(maxWidth: .infinity, alignment: .leading)
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.horizontal, 28)
@@ -118,11 +112,12 @@ struct SettingsView: View {
                             .foregroundColor(.white)
                             .padding(.horizontal, 16)
                             .padding(.vertical, 8)
-                            .background(isFormValid ? Color.appPrimary : Color(red: 255/255.0, green: 240/255.0, blue: 245/255.0))
+                            .background(isFormValid ? Color.appPrimary : Color.appPrimary.opacity(0.5))
                             .cornerRadius(20)
                     }
                     .disabled(!isFormValid)
                     .buttonStyle(.plain)
+                    .background(Color.clear)
                 }
             }
         }


### PR DESCRIPTION
## 변경사항

- Syncly 제목 추가 및 카드 여백과 동일한 위치로 조정
- 비활성화된 알람 카드에 회색 틴트 적용
- 알람 폼 UI 개선 (폰트, 간격, 색상 등)
- 설정 화면에서 기본 국가 안내 문구 제거
- 모든 빌드 워닝 제거