### PR TITLE
feat: 스플래시 화면 구현

### DIFF
--- a/TimezoneAlarm.xcodeproj/project.pbxproj
+++ b/TimezoneAlarm.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		694c41ecac5043e7aa3f3d070dd315aa /* AlarmScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = a1b2c3d4e5f6a7b8c9d0e1f2 /* AlarmScheduler.swift */; };
 		51C503CA6D2F46F88D80A5DF /* TimezoneAlarmApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BB57D6CC548EA702320A886 /* TimezoneAlarmApp.swift */; };
 		9BCFF78819A255F7ECC7C92C /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB581C9CBC9D09BF2208EFC /* ContentView.swift */; };
+		E1F2A3B4C5D6E7F8A9B0C1D2E3 /* AppRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2A3B4C5D6E7F8A9B0C1D2E3F4 /* AppRootView.swift */; };
+		A3B4C5D6E7F8A9B0C1D2E3F4A5 /* SplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C5D6E7F8A9B0C1D2E3F4A5B6 /* SplashView.swift */; };
 		4d7f560ed097476cae0cd291 /* alarm.wav in Resources */ = {isa = PBXBuildFile; fileRef = 5012fb61d559485e91c01c68 /* alarm.wav */; };
 		A9B8C7D6E5F4A3B2C1D0E9F8 /* alarm-icon.png in Resources */ = {isa = PBXBuildFile; fileRef = B0C1D2E3F4A5B6C7D8E9F0A1 /* alarm-icon.png */; };
 		C1D2E3F4A5B6C7D8E9F0A1B2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D2E3F4A5B6C7D8E9F0A1B2C3D4 /* Assets.xcassets */; };
@@ -58,6 +60,8 @@
 		7cf857b200ed4242858a4214 /* AlarmCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlarmCardView.swift; sourceTree = "<group>"; };
 		b0c1d2e3f4a5b6c7d8e9f0a1 /* TrashIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrashIconView.swift; sourceTree = "<group>"; };
 		BAB581C9CBC9D09BF2208EFC /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		F2A3B4C5D6E7F8A9B0C1D2E3F4 /* AppRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRootView.swift; sourceTree = "<group>"; };
+		B4C5D6E7F8A9B0C1D2E3F4A5B6 /* SplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashView.swift; sourceTree = "<group>"; };
 		C9280CEC28D1C9EB1F6C08BB /* TimezoneAlarmTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = TimezoneAlarmTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		CB864B139FD73FF46A788586 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		c0d93f8293644af99db05acb /* AlarmViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlarmViewModel.swift; sourceTree = "<group>"; };
@@ -129,6 +133,8 @@
 				a1b2c3d4e5f6a7b8c9d0e1f4 /* AlarmAlertView.swift */,
 				c3d4e5f6a7b8c9d0e1f2a3b4 /* SettingsView.swift */,
 				b0c1d2e3f4a5b6c7d8e9f0a1 /* TrashIconView.swift */,
+				F2A3B4C5D6E7F8A9B0C1D2E3F4 /* AppRootView.swift */,
+				B4C5D6E7F8A9B0C1D2E3F4A5B6 /* SplashView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -269,6 +275,8 @@
 				694c41ecac5043e7aa3f3d070dd315aa /* AlarmScheduler.swift in Sources */,
 				9BCFF78819A255F7ECC7C92C /* ContentView.swift in Sources */,
 				51C503CA6D2F46F88D80A5DF /* TimezoneAlarmApp.swift in Sources */,
+				E1F2A3B4C5D6E7F8A9B0C1D2E3 /* AppRootView.swift in Sources */,
+				A3B4C5D6E7F8A9B0C1D2E3F4A5 /* SplashView.swift in Sources */,
 				F8E9D0A1B2C3D4E5F6A7B8C9 /* Logger.swift in Sources */,
 				D1E2F3A4B5C6D7E8F9A0B1C2 /* DesignSystem.swift in Sources */,
 			);

--- a/TimezoneAlarm/TimezoneAlarmApp.swift
+++ b/TimezoneAlarm/TimezoneAlarmApp.swift
@@ -51,7 +51,7 @@ struct TimezoneAlarmApp: App {
     
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            AppRootView()
                 .environmentObject(NotificationDelegate.shared)
         }
     }

--- a/TimezoneAlarm/Views/AppRootView.swift
+++ b/TimezoneAlarm/Views/AppRootView.swift
@@ -1,0 +1,31 @@
+//
+//  AppRootView.swift
+//  TimezoneAlarm
+//
+//  Created on 2024.
+//
+
+import SwiftUI
+
+struct AppRootView: View {
+    @State private var showSplash = true
+    
+    var body: some View {
+        ZStack {
+            if showSplash {
+                SplashView(isPresented: $showSplash)
+                    .transition(.opacity)
+            } else {
+                ContentView()
+                    .transition(.opacity)
+            }
+        }
+        .animation(.easeInOut(duration: 0.6), value: showSplash)
+    }
+}
+
+#Preview {
+    AppRootView()
+        .environmentObject(NotificationDelegate.shared)
+}
+

--- a/TimezoneAlarm/Views/SplashView.swift
+++ b/TimezoneAlarm/Views/SplashView.swift
@@ -1,0 +1,73 @@
+//
+//  SplashView.swift
+//  TimezoneAlarm
+//
+//  Created on 2024.
+//
+
+import SwiftUI
+
+struct SplashView: View {
+    @State private var opacity: Double = 0.0
+    @Binding var isPresented: Bool
+    
+    var body: some View {
+        ZStack {
+            // 알람 실행 화면과 동일한 그라데이션 백그라운드
+            LinearGradient(
+                colors: [Color.appBackgroundTop, Color.appBackgroundBottom],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+            .ignoresSafeArea()
+            
+            GeometryReader { geometry in
+                VStack(spacing: 0) {
+                    Spacer()
+                        .frame(height: geometry.size.height * 0.2)
+                    
+                    // 알람 아이콘
+                    Image("alarm-icon")
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 270, height: 270)
+                        .opacity(opacity)
+                    
+                    // Syncly 제목
+                    Text("Syncly")
+                        .font(.geist(size: 48, weight: .bold))
+                        .foregroundColor(.appTextPrimary)
+                        .padding(.top, 12)
+                        .opacity(opacity)
+                    
+                    // 서브타이틀
+                    Text("Alarms in sync with every city")
+                        .font(.geist(size: 20, weight: .light))
+                        .foregroundColor(.appTextSecondary)
+                        .padding(.top, 6)
+                        .opacity(opacity)
+                    
+                    Spacer()
+                        .frame(height: geometry.size.height * 0.8)
+                }
+                .frame(width: geometry.size.width)
+            }
+        }
+        .onAppear {
+            // 조용한 fade in 애니메이션
+            withAnimation(.easeIn(duration: 0.5)) {
+                opacity = 1.0
+            }
+            
+            // 2초 후 바로 화면 전환 (fade out 없음)
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+                isPresented = false
+            }
+        }
+    }
+}
+
+#Preview {
+    SplashView(isPresented: .constant(true))
+}
+


### PR DESCRIPTION
## 변경사항

### 스플래시 화면
- 알람 실행 화면과 동일한 그라데이션 배경 적용
- 가운데 알람 아이콘 (270x270)
- Syncly 타이틀 (48pt, bold)
- Alarms in sync with every city 서브타이틀 (20pt, light)
- fade in 0.5초, 대기 2초 후 바로 전환
- 위에서 20% 위치부터 시작
- 좌우 가운데 정렬 유지

### 구현 파일
- `SplashView.swift`: 스플래시 화면 뷰
- `AppRootView.swift`: 스플래시와 메인 화면 전환 관리
- `TimezoneAlarmApp.swift`: AppRootView 사용하도록 수정

Closes #20