### PR TITLE
Fix test failures and add test files to project

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -11,6 +11,10 @@ target 'TimezoneAlarm' do
 
 end
 
+target 'TimezoneAlarmTests' do
+  inherit! :search_paths
+end
+
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     target.build_configurations.each do |config|

--- a/TimezoneAlarm.xcodeproj/project.pbxproj
+++ b/TimezoneAlarm.xcodeproj/project.pbxproj
@@ -42,6 +42,8 @@
 		e487a86a7e78475ea73ee53738752ed0 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 69189974529b46abb4ddc4567e78fd49 /* Localizable.strings */; };
 		f09dd84d11e9481c8d0f0cd11265d115 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 6257a08d2a254cb4a78efde9368ba791 /* Localizable.strings */; };
 		f3fa27104f814f279aea8cf6 /* AlarmListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2055e47b01704302b9a69f9c /* AlarmListView.swift */; };
+		T1E2S3T4F5I6L7E8A9B0C1D2E3F4A5 /* TimezoneConversionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T1E2S3T4F5I6L7E8A9B0C1D2E3F4A6 /* TimezoneConversionTests.swift */; };
+		T1E2S3T4F5I6L7E8A9B0C1D2E3F4A7 /* DaylightSavingTimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T1E2S3T4F5I6L7E8A9B0C1D2E3F4A8 /* DaylightSavingTimeTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -95,6 +97,8 @@
 		c926d1891e7e466b9a173335a435283e /* Localizable.strings */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = TimezoneAlarm/Resources/en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		e5f6a7b8c9d0e1f2a3b4c5d6 /* InitialSetupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InitialSetupView.swift; sourceTree = "<group>"; };
 		f1c854c0da854c6da495d9c1 /* AlarmFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlarmFormView.swift; sourceTree = "<group>"; };
+		T1E2S3T4F5I6L7E8A9B0C1D2E3F4A6 /* TimezoneConversionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimezoneConversionTests.swift; sourceTree = "<group>"; };
+		T1E2S3T4F5I6L7E8A9B0C1D2E3F4A8 /* DaylightSavingTimeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaylightSavingTimeTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -143,6 +147,8 @@
 		304F26C114F1E943094D4896 /* TimezoneAlarmTests */ = {
 			isa = PBXGroup;
 			children = (
+				T1E2S3T4F5I6L7E8A9B0C1D2E3F4A6 /* TimezoneConversionTests.swift */,
+				T1E2S3T4F5I6L7E8A9B0C1D2E3F4A8 /* DaylightSavingTimeTests.swift */,
 			);
 			path = TimezoneAlarmTests;
 			sourceTree = "<group>";
@@ -424,6 +430,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				T1E2S3T4F5I6L7E8A9B0C1D2E3F4A5 /* TimezoneConversionTests.swift in Sources */,
+				T1E2S3T4F5I6L7E8A9B0C1D2E3F4A7 /* DaylightSavingTimeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -503,6 +511,7 @@
 		};
 		26111A5CE0E59A7D6B32EC1B /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 00D013649BF8D3C5938D2598 /* Pods-TimezoneAlarm.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				GENERATE_INFOPLIST_FILE = YES;
@@ -546,6 +555,7 @@
 		};
 		36F910E58F7697F7A951AE91 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = A9751D7E0C19685C20776C40 /* Pods-TimezoneAlarm.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				DEVELOPMENT_TEAM = 9Q6XC7XQJN;

--- a/TimezoneAlarmTests/DaylightSavingTimeTests.swift
+++ b/TimezoneAlarmTests/DaylightSavingTimeTests.swift
@@ -13,47 +13,54 @@ final class DaylightSavingTimeTests: XCTestCase {
     /// 서머타임 시작 시점 테스트 (봄)
     /// 미국 서머타임은 3월 둘째 일요일 오전 2시에 시작
     func testDSTStart() {
-        // 2024년 3월 10일 (일요일) - 서머타임 시작일
-        let calendar = Calendar.current
-        var components = DateComponents()
-        components.year = 2024
-        components.month = 3
-        components.day = 10
-        components.hour = 2
-        components.minute = 0
-        components.timeZone = TimeZone(identifier: "America/Los_Angeles")
-        
-        guard let dstStartDate = calendar.date(from: components) else {
-            XCTFail("서머타임 시작 날짜 생성 실패")
+        guard let laTimezone = TimeZone(identifier: "America/Los_Angeles") else {
+            XCTFail("LA 시간대를 찾을 수 없습니다")
             return
         }
         
-        // 서머타임 시작 전 (PST, UTC-8)
-        var beforeDST = components
+        let calendar = Calendar.current
+        
+        // 서머타임 시작 전 (3월 10일 1:59 AM PST, UTC-8)
+        var beforeDST = DateComponents()
+        beforeDST.year = 2024
+        beforeDST.month = 3
+        beforeDST.day = 10
         beforeDST.hour = 1
         beforeDST.minute = 59
+        beforeDST.timeZone = laTimezone
+        
         guard let beforeDSTDate = calendar.date(from: beforeDST) else {
             XCTFail("서머타임 시작 전 날짜 생성 실패")
             return
         }
         
-        // 서머타임 시작 후 (PDT, UTC-7)
-        var afterDST = components
+        // 서머타임 시작 후 (3월 10일 3:00 AM PDT, UTC-7) - 2:00 AM이 건너뛰어짐
+        var afterDST = DateComponents()
+        afterDST.year = 2024
+        afterDST.month = 3
+        afterDST.day = 10
         afterDST.hour = 3
         afterDST.minute = 0
+        afterDST.timeZone = laTimezone
+        
         guard let afterDSTDate = calendar.date(from: afterDST) else {
             XCTFail("서머타임 시작 후 날짜 생성 실패")
             return
         }
         
         // UTC 변환 확인
+        // 서머타임 시작으로 인해 시간대가 UTC-8에서 UTC-7로 바뀌므로
+        // 1:59 AM PST와 3:00 AM PDT는 UTC에서는 1분 차이만 남
         let beforeDSTUTC = beforeDSTDate.timeIntervalSince1970
         let afterDSTUTC = afterDSTDate.timeIntervalSince1970
         let timeDifference = afterDSTUTC - beforeDSTUTC
         
-        // 서머타임 시작으로 인해 1시간이 건너뛰어지므로, 실제 시간 차이는 1시간이어야 함
-        // 하지만 날짜상으로는 2시간 차이가 나야 함 (1:59 -> 3:00)
-        XCTAssertEqual(timeDifference, 3600, accuracy: 60, "서머타임 시작 시 1시간이 건너뛰어져야 합니다")
+        // 실제로는 1분 차이 (60초)
+        XCTAssertEqual(timeDifference, 60, accuracy: 5, "서머타임 시작 시 로컬 시간은 1시간 1분 차이지만 UTC는 1분 차이입니다")
+        
+        // 로컬 시간 차이 확인 (1시간 1분 = 3660초)
+        let localTimeDifference = (afterDST.hour! * 3600 + afterDST.minute! * 60) - (beforeDST.hour! * 3600 + beforeDST.minute! * 60)
+        XCTAssertEqual(localTimeDifference, 3660, "로컬 시간 차이는 1시간 1분(3660초)이어야 합니다")
     }
     
     /// 서머타임 종료 시점 테스트 (가을)

--- a/TimezoneAlarmTests/TimezoneConversionTests.swift
+++ b/TimezoneAlarmTests/TimezoneConversionTests.swift
@@ -27,23 +27,14 @@ final class TimezoneConversionTests: XCTestCase {
         let calendar = Calendar.current
         let now = Date()
         
-        // 현재 시간을 기준으로 다음 목요일 찾기
-        var targetDate = now
-        let todayComponents = calendar.dateComponents(in: seoulTimezone, from: now)
-        if todayComponents.weekday == 5 {
-            // 오늘이 목요일이면 오늘 사용
-            targetDate = now
-        } else {
-            // 다음 주 목요일로
-            targetDate = calendar.date(byAdding: .weekOfYear, value: 1, to: now) ?? now
-        }
-        
-        // 서울 시간대에서 목요일 9시를 UTC로 변환
-        var seoulComponents = calendar.dateComponents(in: seoulTimezone, from: targetDate)
+        // 고정된 날짜 사용: 2024년 11월 21일 (목요일)
+        var seoulComponents = DateComponents()
+        seoulComponents.year = 2024
+        seoulComponents.month = 11
+        seoulComponents.day = 21
         seoulComponents.hour = 9
         seoulComponents.minute = 0
         seoulComponents.second = 0
-        seoulComponents.weekday = 5 // 목요일
         seoulComponents.timeZone = seoulTimezone
         
         guard let seoulTimeUTC = calendar.date(from: seoulComponents) else {


### PR DESCRIPTION
## 주요 변경사항

- 테스트 파일을 Xcode 프로젝트에 추가
  - TimezoneConversionTests.swift와 DaylightSavingTimeTests.swift를 project.pbxproj에 추가
  - PBXBuildFile, PBXFileReference, PBXGroup, PBXSourcesBuildPhase에 참조 추가

- 테스트 타겟에 Pods 의존성 추가
  - 테스트 타겟의 Debug/Release 빌드 설정에 Pods xcconfig 참조 추가
  - Firebase 모듈을 찾을 수 있도록 설정
  - Podfile에 테스트 타겟 추가 (inherit! :search_paths)

- 실패한 테스트 수정
  - testDSTStart: 서머타임 시작 시점의 UTC vs 로컬 시간 차이 로직 수정
  - testSeoulToLAConversion: 현재 날짜 의존성 제거, 고정된 날짜 사용

## 테스트 결과
✅ 모든 테스트 통과 (5개 테스트, 0 실패)
✅ 프리커밋 훅에서 테스트 정상 실행